### PR TITLE
bugfix: out-of-bounds read error in graph setup

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -95,14 +95,14 @@ int main()
 			if ((i == 0) || (j == 0) || (i == m - 1) || (j == n - 1)) {
 				(*(test[j + i*n])).passable = false;
 			}
-			if (i > 0)
+			if (i > 0 && j > 0) {
 				(*(test[j + i*n])).Left = ((test[(j - 1) + i*n]));
-			if (i < m - 1)
-				(*(test[j + i*n])).Right = ((test[(j + 1) + i*n]));
-			if (j > 0)
 				(*(test[j + i*n])).Up = ((test[j + (i - 1)*n]));
-			if (j < n - 1)
+            }
+			if (i < m - 1 && j < n - 1) {
+				(*(test[j + i*n])).Right = ((test[(j + 1) + i*n]));
 				(*(test[j + i*n])).Down = ((test[j + (i + 1)*n]));
+            }
 
 		}
 	}


### PR DESCRIPTION
I think this is the bug that you mentioned. It shows up in valgrind and it causes a SIGSEGV on Linux.
